### PR TITLE
Adding `docker-compose` example

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,18 @@ containers:
             detach: false
 ```
 
+# Docker Compose
+If you are using [Docker Compose](https://docs.docker.com/compose/) linking the folder `app` works as follows
+```yaml
+web:
+  image: ntboes/golang-gin
+  command: gin
+  ports:
+   - "3000:3000"
+  volumes:
+   - app:/go/src/app
+```
+
 # Arguments
 All flags after the image name in the docker command are forwarded to gin, e.g to set the port of gin to 4000:
 ```shell


### PR DESCRIPTION
Adding a `docker-compose` example for people not using crane. This example worked for me.
