### PR TITLE
path flexibility update

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM golang:wheezy
 
-RUN mkdir -p /go/src/github.com/colldesk
-WORKDIR /go/src/github.com/colldesk
+RUN mkdir -p $WORKDIR
+WORKDIR $WORKDIR
 
 RUN go get github.com/codegangsta/gin
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM golang:wheezy
 
-RUN mkdir -p $WORKDIR
-WORKDIR $WORKDIR
+RUN mkdir -p /go/src/github.com/colldesk
+WORKDIR /go/src/github.com/colldesk
 
 RUN go get github.com/codegangsta/gin
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM golang:wheezy
 
-RUN mkdir -p /go/src/app
-WORKDIR /go/src/app
+RUN mkdir -p /go/src/github.com/colldesk
+WORKDIR /go/src/github.com/colldesk
 
 RUN go get github.com/codegangsta/gin
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,8 @@
 FROM golang:wheezy
 
-RUN mkdir -p /go/src/github.com/colldesk
-WORKDIR /go/src/github.com/colldesk
+RUN mkdir -p /go/src/github.com
+WORKDIR /go/src/github.com
+ENV WORKINGDIR /go/src/github.com
 
 RUN go get github.com/codegangsta/gin
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 ## Docker Image for Golang development with Gin
 ========
+This container is based on the excellent work done in ntboes/golang-gin. It deals with 2 problems I encountered:
+- the container start is slow if the volume is only making your own code available to the container. I suggest linking your entire $GOPATH/src directory, so dependencies are already available and do not need to download on startup.
+- your app had to be placed into /go/src/app or the container would not work. Now you can configure the WORKINGDIR environment variable to suit your need. The main go file has to reside in WORKINGDIR.
+
 This docker image takes advantage of [Gin](https://github.com/codegangsta/gin) in order to allow running a Go Application in a Docker container with live reloading.
 The image is based on the official golang:wheezy image.
 

--- a/README.md
+++ b/README.md
@@ -3,6 +3,27 @@
 This docker image takes advantage of [Gin](https://github.com/codegangsta/gin) in order to allow running a Go Application in a Docker container with live reloading.
 The image is based on the official golang:wheezy image.
 
+## Usage
+
+# Docker
+Run a docker container with your app in the current folder
+```shell
+docker run --name some-instance-name -v $(pwd):/go/src tehsphinx/docker-golang-gin
+```
+
+# Crane
+If you are using [Crane](https://github.com/michaelsauter/crane) linking the folder `app` works as follows
+```yaml
+containers:
+    stratus_app:
+        image: tehsphinx/docker-golang-gin
+        run:
+            volume: ["./../..:/go/src"]
+            publish: ["3000:3000"]
+            detach: false
+```
+TODO: sample correct setting of environment variable.
+
 # Docker Compose
 If you are using [Docker Compose](https://docs.docker.com/compose/) linking the folder `app` works as follows
 ```yaml
@@ -13,6 +34,15 @@ web:
    - "3000:3000"
   volumes:
    - ./../..:/go/src
+  environment:
+   - WORKINGDIR=/go/src/github.com/yourname/yourapp
 ```
+The WORKDIR environment variable is useful if you want to link in all of your dependencies (e.g. link /go/src/) and not move your app to /go/src/app.
+Just point WORKDIR to your app e.g. WORKDIR=/go/src/github.com/yourname/yourapp
 
+# Arguments
+All flags after the image name in the docker command are forwarded to gin, e.g to set the port of gin to 4000:
+```shell
+docker run --name some-instance-name -v $(pwd):/go/src tehsphinx/docker-golang-gin -p 4000
+```
 For further info see: [Gin](https://github.com/codegangsta/gin) or `gin -h`.

--- a/README.md
+++ b/README.md
@@ -3,47 +3,16 @@
 This docker image takes advantage of [Gin](https://github.com/codegangsta/gin) in order to allow running a Go Application in a Docker container with live reloading.
 The image is based on the official golang:wheezy image.
 
-## Usage
-In order to enable live reloading, the source folder of your app needs to be linked to `/go/src/app`.
-
-# Docker
-Run a docker container with your app in the current folder
-```shell
-docker run --name some-instance-name -v $(pwd):/go/src/app ntboes/golang-gin
-```
-
-# Crane
-If you are using [Crane](https://github.com/michaelsauter/crane) linking the folder `app` works as follows
-```yaml
-containers:
-    stratus_app:
-        image: ntboes/golang-gin
-        run:
-            volume: ["app:/go/src/app"]
-            publish: ["3000:3000"]
-            detach: false
-```
-
 # Docker Compose
 If you are using [Docker Compose](https://docs.docker.com/compose/) linking the folder `app` works as follows
 ```yaml
 web:
-  image: ntboes/golang-gin
+  image: tehsphinx/docker-golang-gin
   command: gin
   ports:
    - "3000:3000"
   volumes:
-   - app:/go/src/app
-  environment:
-   - WORKDIR=/go/src/app
+   - ./../..:/go/src
 ```
-The WORKDIR environment variable is useful if you want to link in all of your dependencies (e.g. link /go/src/) and not move your app to /go/src/app.
-Just point WORKDIR to your app e.g. WORKDIR=/go/src/github.com/yourname/yourapp/main.
 
-
-# Arguments
-All flags after the image name in the docker command are forwarded to gin, e.g to set the port of gin to 4000:
-```shell
-docker run --name some-instance-name -v $(pwd):/go/src/app ntboes/golang-gin -p 4000
-```
 For further info see: [Gin](https://github.com/codegangsta/gin) or `gin -h`.

--- a/README.md
+++ b/README.md
@@ -34,7 +34,12 @@ web:
    - "3000:3000"
   volumes:
    - app:/go/src/app
+  environment:
+   - WORKDIR=/go/src/app
 ```
+The WORKDIR environment variable is useful if you want to link in all of your dependencies (e.g. link /go/src/) and not move your app to /go/src/app.
+Just point WORKDIR to your app e.g. WORKDIR=/go/src/github.com/yourname/yourapp/main.
+
 
 # Arguments
 All flags after the image name in the docker command are forwarded to gin, e.g to set the port of gin to 4000:

--- a/installAndStart.sh
+++ b/installAndStart.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-cd /go/src/app
+cd $WORKINGDIR
 go-wrapper download
 go-wrapper install
 #check and install gin if missing i.e. go directory was overriden or mounted


### PR DESCRIPTION
Hi there!

I made this update to be able to work with this container on our project. It solves two issues I encountered:
- all the dependencies need to be downloaded every time. (Solution: map your entire $GOPATH/src to the container)
- your app needs to be placed in ./src/app which is kind of against the rules of golang. With the ENV WORKINGDIR we are able to leave that to the developer. For example WORKINGDIR=/go/src/github.com/yourname/yourapp/
